### PR TITLE
bugFix. 제휴 업체 이미지 사이즈 변경

### DIFF
--- a/apps/web/src/components/home/partnership/partnership.tsx
+++ b/apps/web/src/components/home/partnership/partnership.tsx
@@ -123,7 +123,6 @@ const Partnership = ({ isMobile }: PartnershipProps) => {
                     <Wrapper.Item
                       css={css`
                         width: 285px;
-                        height: 180px;
                         flex: none;
                         display: flex;
                         flex-direction: column;
@@ -148,6 +147,7 @@ const Partnership = ({ isMobile }: PartnershipProps) => {
                           fill
                           style={{
                             borderRadius: '4px',
+                            minHeight: '180px',
                           }}
                           sizes={`${applyMediaQuery(
                             'desktop'


### PR DESCRIPTION
## 내용
1. 메인 페이지 제휴 업체 영역에 피그마에 맞게 래퍼에 세로 사이즈 제거 및 이미지의 세로 사이즈 180px 추가